### PR TITLE
Disable workflow for node v14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We are incompatible with node 14 so disabling this.