### PR TITLE
Fix size and paddings of pig icon in the switch

### DIFF
--- a/ham-www/src/components/TopBar/components/ThemeToggle.tsx
+++ b/ham-www/src/components/TopBar/components/ThemeToggle.tsx
@@ -69,8 +69,8 @@ const StyledThemeToggle = styled.button<StyledThemeToggleProps>`
 
   svg {
     height: auto;
-    padding: 2px 2px 2px 2px;
-    width: 2rem;
+    padding: 5px 2px 2px 2px;
+    width: 1.6rem;
     transition: all 0.25s linear;
 
     // Sun icon.


### PR DESCRIPTION
## What?
Fix size and paddings of pig icon in the switch. 

## Previews
### Before:
<img width="452" alt="Screenshot 2020-09-02 at 23 04 31" src="https://user-images.githubusercontent.com/69689770/92031553-70561b00-ed71-11ea-86ac-723a94b2657a.png">

### After:
<img width="409" alt="Screenshot 2020-09-02 at 23 07 08" src="https://user-images.githubusercontent.com/69689770/92031566-75b36580-ed71-11ea-91b5-81640fd7ccbb.png">

<img width="336" alt="Screenshot 2020-09-02 at 23 07 13" src="https://user-images.githubusercontent.com/69689770/92031580-7cda7380-ed71-11ea-9445-6cbf50962166.png">
